### PR TITLE
Plug the audio-playback interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,7 @@ layout:
 plugs:
   wayland:
   opengl:
+  audio-playback:
   pulseaudio:
   alsa:
 
@@ -66,7 +67,7 @@ parts:
   mir-kiosk-snap-launch:
     plugin: dump
     source: https://github.com/MirServer/mir-kiosk-snap-launch.git
-    override-build:  $SNAPCRAFT_PART_BUILD/build-with-plugs.sh opengl pulseaudio alsa wayland
+    override-build:  $SNAPCRAFT_PART_BUILD/build-with-plugs.sh opengl audio-playback pulseaudio alsa wayland
 
   scummvm:
     plugin: nil


### PR DESCRIPTION
When running as a daemon, always restarthttps://forum.snapcraft.io/t/upcoming-pulseaudio-interface-deprecation/13418

"If your snap currently plugs: [ pulseaudio ], you may want to opt into future-proofing and adjust it to use plugs: [ audio-playback, pulseaudio ] (adding audio-record as desired). Again, this is not required for existing snaps since they will be grandfathered into auto-connection."